### PR TITLE
hardening/valgrind_errors_02

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,2 @@
 - Fix: missing lastSuccess/lastFailure associated to initial notification on subscription creation some times when csub cache is in use (#2974)
+- Fix: several invalid memory accesses (based on a workaround, not a definitive solution, see issue #2994)

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -100,11 +100,64 @@ static std::string          subscribeContextAvailabilityCollectionName;
 static Notifier*            notifier;
 static bool                 multitenant;
 
+thread_local std::vector<ContextElementResponse*>  savedCerVector;
+
 
 
 /* ****************************************************************************
 *
-* mongoMultitenant - 
+* WORKAROUND_2994 - see github issue 2994
+*/
+#define WORKAROUND_2994 1
+
+
+
+
+#ifdef WORKAROUND_2994
+/* ****************************************************************************
+*
+* delayedReleaseAdd -
+*/
+static void delayedReleaseAdd(ContextElementResponseVector& cerV)
+{
+  for (unsigned int ix = 0; ix < cerV.size(); ++ix)
+    savedCerVector.push_back(cerV[ix]);
+}
+#endif
+
+
+
+/* ****************************************************************************
+*
+* delayedReleaseExecute -
+*
+* NOTE
+*   This function doesn't depend on WORKAROUND_2994 being defined as savedCerVector
+*   will be empty if WORKAROUND_2994 is not defined and its action is null and void, if so.
+*   'delayedReleaseExecute()' is called in rest/rest.cpp and with this 'idea', that file doesn't
+*   need to know about the WORKAROUND_2994 definition.
+*/
+void delayedReleaseExecute(void)
+{
+  if (savedCerVector.size() == 0)
+  {
+    return;
+  }
+
+  for (unsigned int ix = 0; ix < savedCerVector.size(); ++ix)
+  {
+    savedCerVector[ix]->release();
+    delete savedCerVector[ix];
+  }
+
+  savedCerVector.clear();
+}
+
+
+
+/* ****************************************************************************
+*
+* mongoMultitenant -
 */
 bool mongoMultitenant(void)
 {
@@ -750,7 +803,7 @@ BSONObj fillQueryServicePath(const std::vector<std::string>& servicePath)
    *
    * More information on: http://stackoverflow.com/questions/24243276/include-regex-elements-in-bsonarraybuilder
    *
-   */  
+   */
 
   //
   // Note that by construction servicePath vector must have at least one element. Note that the
@@ -1515,7 +1568,7 @@ void pruneContextElements(const ContextElementResponseVector& oldCerV, ContextEl
 {
   for (unsigned int ix = 0; ix < oldCerV.size(); ++ix)
   {
-    ContextElementResponse* cerP = oldCerV[ix];
+    ContextElementResponse* cerP    = oldCerV[ix];
     ContextElementResponse* newCerP = new ContextElementResponse();
 
     /* Note we cannot use the ContextElement::fill() method, given that it also copies the ContextAttributeVector. The side-effect
@@ -2037,7 +2090,13 @@ static bool processOnChangeConditionForSubscription
 
   /* Prune "not found" CERs */
   pruneContextElements(rawCerV, &ncr.contextElementResponseVector);
+
+#ifdef WORKAROUND_2994
+  delayedReleaseAdd(rawCerV);
+  rawCerV.vec.clear();
+#else
   rawCerV.release();
+#endif
 
 #if 0
   // FIXME #920: disabled for the moment, maybe to be removed in the end
@@ -2064,7 +2123,12 @@ static bool processOnChangeConditionForSubscription
 
       if (!entitiesQuery(enV, emptyList, metadataList, *resP, &rawCerV, &err, false, tenant, servicePathV))
       {
+#ifdef WORKAROUND_2994
+        delayedReleaseAdd(rawCerV);
+        rawCerV.vec.clear();
+#else
         rawCerV.release();
+#endif
         ncr.contextElementResponseVector.release();
 
         return false;
@@ -2072,7 +2136,13 @@ static bool processOnChangeConditionForSubscription
 
       /* Prune "not found" CERs */
       pruneContextElements(rawCerV, &allCerV);
+
+#ifdef WORKAROUND_2994
+      delayedReleaseAdd(rawCerV);
+      rawCerV.vec.clear();
+#else
       rawCerV.release();
+#endif
 
       if (isCondValueInContextElementResponse(condValues, &allCerV))
       {

--- a/src/lib/mongoBackend/MongoGlobal.cpp
+++ b/src/lib/mongoBackend/MongoGlobal.cpp
@@ -100,13 +100,13 @@ static std::string          subscribeContextAvailabilityCollectionName;
 static Notifier*            notifier;
 static bool                 multitenant;
 
-thread_local std::vector<ContextElementResponse*>  savedCerVector;
+thread_local std::vector<ContextElementResponse*>  cerVectorForDelayedRelease;
 
 
 
 /* ****************************************************************************
 *
-* WORKAROUND_2994 - see github issue 2994
+* WORKAROUND_2994 - see github issue #2994
 */
 #define WORKAROUND_2994 1
 
@@ -121,7 +121,7 @@ thread_local std::vector<ContextElementResponse*>  savedCerVector;
 static void delayedReleaseAdd(ContextElementResponseVector& cerV)
 {
   for (unsigned int ix = 0; ix < cerV.size(); ++ix)
-    savedCerVector.push_back(cerV[ix]);
+    cerVectorForDelayedRelease.push_back(cerV[ix]);
 }
 #endif
 
@@ -132,25 +132,25 @@ static void delayedReleaseAdd(ContextElementResponseVector& cerV)
 * delayedReleaseExecute -
 *
 * NOTE
-*   This function doesn't depend on WORKAROUND_2994 being defined as savedCerVector
+*   This function doesn't depend on WORKAROUND_2994 being defined as cerVectorForDelayedRelease
 *   will be empty if WORKAROUND_2994 is not defined and its action is null and void, if so.
 *   'delayedReleaseExecute()' is called in rest/rest.cpp and with this 'idea', that file doesn't
 *   need to know about the WORKAROUND_2994 definition.
 */
 void delayedReleaseExecute(void)
 {
-  if (savedCerVector.size() == 0)
+  if (cerVectorForDelayedRelease.size() == 0)
   {
     return;
   }
 
-  for (unsigned int ix = 0; ix < savedCerVector.size(); ++ix)
+  for (unsigned int ix = 0; ix < cerVectorForDelayedRelease.size(); ++ix)
   {
-    savedCerVector[ix]->release();
-    delete savedCerVector[ix];
+    cerVectorForDelayedRelease[ix]->release();
+    delete cerVectorForDelayedRelease[ix];
   }
 
-  savedCerVector.clear();
+  cerVectorForDelayedRelease.clear();
 }
 
 

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -159,6 +159,7 @@ ContextAttribute::ContextAttribute()
   name                  = "";
   type                  = "";
   stringValue           = "";
+  numberValue           = 0;
   valueType             = orion::ValueTypeString;
   compoundValueP        = NULL;
   found                 = false;
@@ -266,6 +267,7 @@ ContextAttribute::ContextAttribute
   name                  = _name;
   type                  = _type;
   stringValue           = std::string(_value);
+  numberValue           = 0;
   valueType             = orion::ValueTypeString;
   compoundValueP        = NULL;
   found                 = _found;
@@ -303,6 +305,7 @@ ContextAttribute::ContextAttribute
   name                  = _name;
   type                  = _type;
   stringValue           = _value;
+  numberValue           = 0;
   valueType             = orion::ValueTypeString;
   compoundValueP        = NULL;
   found                 = _found;
@@ -377,6 +380,7 @@ ContextAttribute::ContextAttribute
   name                  = _name;
   type                  = _type;
   boolValue             = _value;
+  numberValue           = 0;
   valueType             = orion::ValueTypeBoolean;
   compoundValueP        = NULL;
   found                 = _found;
@@ -410,6 +414,7 @@ ContextAttribute::ContextAttribute
   name                  = _name;
   type                  = _type;
   compoundValueP        = _compoundValueP->clone();
+  numberValue           = 0;
   found                 = false;
   valueType             = orion::ValueTypeObject;  // FIXME P6: Could be ValueTypeVector ...
   skip                  = false;

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -656,6 +656,14 @@ static void requestCompleted
     }
   }
 
+
+  //
+  // delayed release of ContextElementResponseVector must be effectuated now.
+  // See github issue 2994
+  //
+  extern void delayedReleaseExecute(void);
+  delayedReleaseExecute();
+
   delete(ciP);
 }
 

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -659,7 +659,7 @@ static void requestCompleted
 
   //
   // delayed release of ContextElementResponseVector must be effectuated now.
-  // See github issue 2994
+  // See github issue #2994
   //
   extern void delayedReleaseExecute(void);
   delayedReleaseExecute();

--- a/test/valgrind/valgrindTestSuite.sh
+++ b/test/valgrind/valgrindTestSuite.sh
@@ -169,7 +169,7 @@ leakTest=off
 dryLeaks=off
 fromIx=0
 ixList=""
-
+file=""
 vMsg "parsing options"
 while [ "$#" != 0 ]
 do
@@ -185,8 +185,14 @@ do
   elif [ "$1" == "-fromIx" ];   then  shift; fromIx=$1;
   elif [ "$1" == "-ixList" ];   then  shift; ixList=$1;
   else
-    echo $0: bad parameter/option: "'"${1}"'";
-    usage 1
+    if [ "$file" == "" ]
+    then
+      file=$1
+      TEST_FILTER=$file
+    else
+      echo $0: bad parameter/option: "'"${1}"'";
+      usage 1
+    fi
   fi
   shift
 done

--- a/test/valgrind/valgrindTestSuite.sh
+++ b/test/valgrind/valgrindTestSuite.sh
@@ -78,7 +78,19 @@ typeset -i valgrindErrors
 #
 function usage()
 {
-  echo $0 "[-u (usage)] [-v (verbose)] [-filter (test filter)] [-dryrun (don't execute any tests)] [-leakTest (test a memory leak)] [-dryLeaks (simulate leaks and functest errors)] [-fromIx (index of test where to start)] [-ixList <list of testNo indexes> ] <pure|harness|both>"
+  sfile="Usage: "$(basename $0)
+  empty=$(echo $sfile | tr 'a-zA-z/0-9.:' ' ')
+
+  echo "$sfile [-u (usage)]"
+  echo "$empty [-v (verbose)]"
+  echo "$empty [-filter <test filter>]"
+  echo "$empty [-dryrun (don't execute any tests)]"
+  echo "$empty [-leakTest (test a memory leak)]"
+  echo "$empty [-dryLeaks (simulate leaks and functest errors)]"
+  echo "$empty [-fromIx <index of test where to start>]"
+  echo "$empty [-ixList <list of testNo indexes>]"
+  echo "$empty [test case file]"
+
   exit $1
 }
 


### PR DESCRIPTION
* Fixed two run-time errors, detected by valgrind (delayed release + an initialization problem)
* Made valgrind test-suite accept a file as parameter (like the functional test harness), not having to use the `-filter` option anymore for this common case (the option still works)