### PR TITLE
Hardening/func test errors after pr 3012

### DIFF
--- a/test/functionalTest/cases/1080_batch_query_context/batch_query_context_error_conditions.test
+++ b/test/functionalTest/cases/1080_batch_query_context/batch_query_context_error_conditions.test
@@ -327,13 +327,13 @@ Date: REGEX(.*)
 11. POST /v2/op/query, with a scope whose 'value' is not a String - see error
 =============================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 89
+Content-Length: 97
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "invalid JSON type for scope value (must be string)",
+    "description": "invalid JSON type for scope value &#40;must be string&#41;",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_errors.test
+++ b/test/functionalTest/cases/1328_pause_subscriptions/pause_subscriptions_errors.test
@@ -187,13 +187,13 @@ Date: REGEX(.*)
 02. POST /v2/subscriptions with string status but not valid (fail)
 ==================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 99
+Content-Length: 107
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "status is not valid (it has to be either active or inactive)",
+    "description": "status is not valid &#40;it has to be either active or inactive&#41;",
     "error": "BadRequest"
 }
 
@@ -225,13 +225,13 @@ Date: REGEX(.*)
 05. PATCH /v2/subscriptions/ID with string status but not valid (fail)
 ======================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 99
+Content-Length: 107
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "status is not valid (it has to be either active or inactive)",
+    "description": "status is not valid &#40;it has to be either active or inactive&#41;",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1607_query_with_q_and_ranges_but_invalid_operator/query_with_q_and_ranges_but_invalid_operator.test
+++ b/test/functionalTest/cases/1607_query_with_q_and_ranges_but_invalid_operator/query_with_q_and_ranges_but_invalid_operator.test
@@ -196,13 +196,13 @@ Date: REGEX(.*)
 05. Erroneous GET entities with q=A1>=0..20
 ===========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 86
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "ranges only valid for == and != ops",
+    "description": "ranges only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 
@@ -210,13 +210,13 @@ Date: REGEX(.*)
 06. Erroneous GET entities with q=A1>0..20
 ==========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 86
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "ranges only valid for == and != ops",
+    "description": "ranges only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 
@@ -224,13 +224,13 @@ Date: REGEX(.*)
 07. Erroneous GET entities with q=A1<=0..20
 ===========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 86
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "ranges only valid for == and != ops",
+    "description": "ranges only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 
@@ -238,13 +238,13 @@ Date: REGEX(.*)
 08. Erroneous GET entities with q=A1<0..20
 ==========================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 86
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "ranges only valid for == and != ops",
+    "description": "ranges only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1678_geosubscriptions/geosubscriptions_errors.test
+++ b/test/functionalTest/cases/1678_geosubscriptions/geosubscriptions_errors.test
@@ -285,13 +285,13 @@ Date: REGEX(.*)
 04. Update subscription with partial geo-parameters (one parameter)
 ===================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 119
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "partial geo expression; geometry, georel and coords have to be provided together",
+    "description": "partial geo expression&#59; geometry, georel and coords have to be provided together",
     "error": "BadRequest"
 }
 
@@ -299,13 +299,13 @@ Date: REGEX(.*)
 05. Update subscription with partial geo-parameters (two parameters)
 ====================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 119
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "partial geo expression; geometry, georel and coords have to be provided together",
+    "description": "partial geo expression&#59; geometry, georel and coords have to be provided together",
     "error": "BadRequest"
 }
 
@@ -313,13 +313,13 @@ Date: REGEX(.*)
 06. Create subscription with partial geo-parameters (one parameter)
 ===================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 119
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "partial geo expression; geometry, georel and coords have to be provided together",
+    "description": "partial geo expression&#59; geometry, georel and coords have to be provided together",
     "error": "BadRequest"
 }
 
@@ -327,13 +327,13 @@ Date: REGEX(.*)
 07. Create subscription with partial geo-parameters (two parameters)
 ====================================================================
 HTTP/1.1 400 Bad Request
-Content-Length: 119
+Content-Length: 123
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "partial geo expression; geometry, georel and coords have to be provided together",
+    "description": "partial geo expression&#59; geometry, georel and coords have to be provided together",
     "error": "BadRequest"
 }
 

--- a/test/functionalTest/cases/1705_csub_cache_objects/csub_cache_objects_errors.test
+++ b/test/functionalTest/cases/1705_csub_cache_objects/csub_cache_objects_errors.test
@@ -361,13 +361,13 @@ Date: REGEX(.*)
 11. GET /v2/entities with > RANGE
 =================================
 HTTP/1.1 400 Bad Request
-Content-Length: 74
+Content-Length: 86
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "ranges only valid for == and != ops",
+    "description": "ranges only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 
@@ -445,13 +445,13 @@ Date: REGEX(.*)
 17. GET /v2/entities with < LIST
 ================================
 HTTP/1.1 400 Bad Request
-Content-Length: 73
+Content-Length: 85
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
 {
-    "description": "lists only valid for == and != ops",
+    "description": "lists only valid for &#61;&#61; and !&#61; ops",
     "error": "BadRequest"
 }
 


### PR DESCRIPTION
Fixed 5 functests that failed after a recent PR.

Not sure I like how it was fixed ...
Perhaps we instead should try to avoid chars that get uriencoded ...

Eg, instead of parenthesis, use colon:
```
    "description": "invalid JSON type for scope value &#40;must be string&#41;",
```
=>
```
    "description": "invalid JSON type for scope value: must be string",
```
Instead of `==` we could use EQ ... ? (not great)
etc, etc

However, we don't need to decide that here and now, just wanted to reflect a little over this.
With this PR, at least the functests work again.