### PR TITLE
Bug/3162 registration destroys compound values

### DIFF
--- a/src/app/contextBroker/contextBroker.cpp
+++ b/src/app/contextBroker/contextBroker.cpp
@@ -823,6 +823,8 @@ int main(int argC, char* argV[])
   paConfig("valid log level strings",       validLogLevels);
   paConfig("default value",                 "-logLevel", "WARN");
 
+  extern void compoundSaveInit(void);
+  compoundSaveInit();
 
   //
   // If option '-fg' is set, print traces to stdout as well, otherwise, only to file

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -52,7 +52,6 @@ using namespace orion;
 
 
 
-#if 0
 typedef struct CompoundSave
 {
   std::string                name;
@@ -64,7 +63,6 @@ typedef struct CompoundSave
 
 static CompoundSave compoundSaveV[100];
 static int          compoundSaveIx = 0;
-#endif
 
 void compoundSaveInit(void)
 {

--- a/src/lib/ngsi/ContextAttribute.cpp
+++ b/src/lib/ngsi/ContextAttribute.cpp
@@ -70,9 +70,9 @@ void compoundSaveInit(void)
     compoundSaveV[ix].state = "unused";
 }
 
+#if 0
 void compoundSaveReport(void)
 {
-#if 0
   LM_TMP(("%-20s %-10s  %-10s  %-10s  %s", "name", "attrP", "compoundP", "from Attr", "state"));
   for (int ix = 0; ix < compoundSaveIx; ix++)
   {
@@ -88,8 +88,8 @@ void compoundSaveReport(void)
     //   compoundSaveV[ix].compoundP = NULL;
     // }
   }
-#endif
 }
+#endif
 
 static void compoundSave(ContextAttribute* aP, ContextAttribute* aParentP)
 {
@@ -335,7 +335,6 @@ ContextAttribute::ContextAttribute(ContextAttribute* caP, bool useDefaultType)
   if (caP->compoundValueP != NULL)
   {
     compoundValueP = caP->compoundValueP->clone();
-    LM_TMP(("Cloned compoundValue for attr '%s' to %p (cloned original at %p)", name.c_str(), compoundValueP, caP->compoundValueP));
     compoundSave(this, caP);
   }
   else
@@ -1271,7 +1270,6 @@ void ContextAttribute::present(const std::string& indent, int ix)
 */
 void ContextAttribute::release(void)
 {
-  LM_TMP(("Releasing attr %s at %p (compound: %p)", name.c_str(), this, compoundValueP));
   compoundUnsave(this);
   if (compoundValueP != NULL)
   {

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -569,6 +569,10 @@ static void requestCompleted
   std::string      spath    = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0] : "";
   struct timespec  reqEndTime;
 
+  LM_TMP(("After %s %s:", ciP->method.c_str(), ciP->url.c_str()));
+  extern void compoundSaveReport(void);
+  compoundSaveReport();
+  
   if ((ciP->payload != NULL) && (ciP->payload != static_buffer))
   {
     free(ciP->payload);
@@ -1246,7 +1250,7 @@ static int connectionTreat
       clock_gettime(CLOCK_REALTIME, &ciP->reqStartTime);
     }
 
-    // LM_TMP(("--------------------- Serving request %s %s -----------------", method, url));
+    LM_TMP(("--------------------- Serving request %s %s -----------------", method, url));
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));

--- a/src/lib/rest/rest.cpp
+++ b/src/lib/rest/rest.cpp
@@ -569,9 +569,7 @@ static void requestCompleted
   std::string      spath    = (ciP->servicePathV.size() > 0)? ciP->servicePathV[0] : "";
   struct timespec  reqEndTime;
 
-  LM_TMP(("After %s %s:", ciP->method.c_str(), ciP->url.c_str()));
-  extern void compoundSaveReport(void);
-  compoundSaveReport();
+  // compoundSaveReport();
   
   if ((ciP->payload != NULL) && (ciP->payload != static_buffer))
   {
@@ -1250,7 +1248,7 @@ static int connectionTreat
       clock_gettime(CLOCK_REALTIME, &ciP->reqStartTime);
     }
 
-    LM_TMP(("--------------------- Serving request %s %s -----------------", method, url));
+    // LM_TMP(("--------------------- Serving request %s %s -----------------", method, url));
     LM_T(LmtRequest, (""));
     // WARNING: This log message below is crucial for the correct function of the Behave tests - CANNOT BE REMOVED
     LM_T(LmtRequest, ("--------------------- Serving request %s %s -----------------", method, url));

--- a/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/blanked_out_attr.test
+++ b/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/blanked_out_attr.test
@@ -1,0 +1,368 @@
+
+# Copyright 2018 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+Federation Problem, basics
+
+--SHELL-INIT--
+dbInit CB
+dbInit CP1
+brokerStart CB 0
+brokerStart CP1 0
+
+--SHELL--
+
+#
+# 
+# 01. Create entity with geodata and string object
+# 02. Check entity in CB
+# 03. Get entity from mongodb
+# 04. Register CP1 for Entity in step 01
+# 05. Check entity in CB
+# 06. Get entity from mongodb
+#
+
+echo "01. Create entity with geodata and string object"
+echo "================================================"
+payload='{
+"actionType": "APPEND",
+  "entities": [
+    {
+      "id":"urn:ngsi-ld:Store:004",
+      "type":"Store",
+      "address": {
+        "type":"PostalAddress",
+        "value": {
+          "streetAddress":"Panoramastrasse 1A",
+          "addressRegion":"Berlin",
+          "addressLocality":"Mitte",
+          "postalCode":"10178"
+        }
+      },
+      "location": {
+        "type":"geo:json",
+        "value": {
+          "type":"Point",
+          "coordinates": [13.4094,52.5208]
+        }
+      },
+      "name": {
+        "type":"Text",
+        "value":"Tower Troddelmarkt"
+      }
+    }
+  ]
+}'
+orionCurl --url /v2/op/update --payload "$payload"
+echo
+echo
+
+
+echo "02. Check entity in CB"
+echo "======================"
+orionCurl --url /v2/entities/urn:ngsi-ld:Store:004
+echo
+echo
+
+
+echo "03. Get entity from mongodb"
+echo "==========================="
+m=$(mongoCmd ${CB_DB_NAME} 'db.entities.find({ "_id" : { "id" : "urn:ngsi-ld:Store:004", "type": "Store", "servicePath" : "/" }})')
+echo $m | python -mjson.tool
+echo
+echo
+
+
+echo "04. Register CP1 for Entity in step 01"
+echo "======================================"
+payload='{
+  "description": "Relative Humidity Context Source",
+  "dataProvided": {
+    "entities": [
+      {
+        "id": "urn:ngsi-ld:Store:004",
+        "type": "Store"
+      }
+    ],
+    "attrs": [
+      "temperature"
+    ]
+  },
+  "provider": {
+    "http": {
+      "url": "http://localhost':$CP1_PORT'/v2"
+    },
+    "legacyForwarding": true
+  }
+}'
+orionCurl --url /v2/registrations --payload "$payload"
+echo
+echo
+
+
+echo "05. Check entity in CB"
+echo "======================"
+orionCurl --url /v2/entities/urn:ngsi-ld:Store:004
+echo
+echo
+
+
+echo "06. Get entity from mongodb"
+echo "==========================="
+m=$(mongoCmd ${CB_DB_NAME} 'db.entities.find({ "_id" : { "id" : "urn:ngsi-ld:Store:004", "type": "Store", "servicePath" : "/" }})')
+echo $m | python -mjson.tool
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity with geodata and string object
+================================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Check entity in CB
+======================
+HTTP/1.1 200 OK
+Content-Length: 381
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "address": {
+        "metadata": {},
+        "type": "PostalAddress",
+        "value": {
+            "addressLocality": "Mitte",
+            "addressRegion": "Berlin",
+            "postalCode": "10178",
+            "streetAddress": "Panoramastrasse 1A"
+        }
+    },
+    "id": "urn:ngsi-ld:Store:004",
+    "location": {
+        "metadata": {},
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                13.4094,
+                52.5208
+            ],
+            "type": "Point"
+        }
+    },
+    "name": {
+        "metadata": {},
+        "type": "Text",
+        "value": "Tower Troddelmarkt"
+    },
+    "type": "Store"
+}
+
+
+03. Get entity from mongodb
+===========================
+{
+    "_id": {
+        "id": "urn:ngsi-ld:Store:004",
+        "servicePath": "/",
+        "type": "Store"
+    },
+    "attrNames": [
+        "address",
+        "location",
+        "name"
+    ],
+    "attrs": {
+        "address": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "PostalAddress",
+            "value": {
+                "addressLocality": "Mitte",
+                "addressRegion": "Berlin",
+                "postalCode": "10178",
+                "streetAddress": "Panoramastrasse 1A"
+            }
+        },
+        "location": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    13.4094,
+                    52.5208
+                ],
+                "type": "Point"
+            }
+        },
+        "name": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "Text",
+            "value": "Tower Troddelmarkt"
+        }
+    },
+    "creDate": REGEX([0-9]+),
+    "lastCorrelator": "REGEX([0-9a-f\-]{36})",
+    "location": {
+        "attrName": "location",
+        "coords": {
+            "coordinates": [
+                13.4094,
+                52.5208
+            ],
+            "type": "Point"
+        }
+    },
+    "modDate": REGEX([0-9]+)
+}
+
+
+04. Register CP1 for Entity in step 01
+======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/registrations/REGEX([0-9a-f\-]{24})
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+05. Check entity in CB
+======================
+HTTP/1.1 200 OK
+Content-Length: 381
+Content-Type: application/json
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+{
+    "address": {
+        "metadata": {},
+        "type": "PostalAddress",
+        "value": {
+            "addressLocality": "Mitte",
+            "addressRegion": "Berlin",
+            "postalCode": "10178",
+            "streetAddress": "Panoramastrasse 1A"
+        }
+    },
+    "id": "urn:ngsi-ld:Store:004",
+    "location": {
+        "metadata": {},
+        "type": "geo:json",
+        "value": {
+            "coordinates": [
+                13.4094,
+                52.5208
+            ],
+            "type": "Point"
+        }
+    },
+    "name": {
+        "metadata": {},
+        "type": "Text",
+        "value": "Tower Troddelmarkt"
+    },
+    "type": "Store"
+}
+
+
+06. Get entity from mongodb
+===========================
+{
+    "_id": {
+        "id": "urn:ngsi-ld:Store:004",
+        "servicePath": "/",
+        "type": "Store"
+    },
+    "attrNames": [
+        "address",
+        "location",
+        "name"
+    ],
+    "attrs": {
+        "address": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "PostalAddress",
+            "value": {
+                "addressLocality": "Mitte",
+                "addressRegion": "Berlin",
+                "postalCode": "10178",
+                "streetAddress": "Panoramastrasse 1A"
+            }
+        },
+        "location": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "geo:json",
+            "value": {
+                "coordinates": [
+                    13.4094,
+                    52.5208
+                ],
+                "type": "Point"
+            }
+        },
+        "name": {
+            "creDate": REGEX([0-9]+),
+            "mdNames": [],
+            "modDate": REGEX([0-9]+),
+            "type": "Text",
+            "value": "Tower Troddelmarkt"
+        }
+    },
+    "creDate": REGEX([0-9]+),
+    "lastCorrelator": "REGEX([0-9a-f\-]{36})",
+    "location": {
+        "attrName": "location",
+        "coords": {
+            "coordinates": [
+                13.4094,
+                52.5208
+            ],
+            "type": "Point"
+        }
+    },
+    "modDate": REGEX([0-9]+)
+}
+
+
+--TEARDOWN--
+brokerStop CB
+brokerStop CP1
+dbDrop CB
+dbDrop CP1

--- a/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/query_for_arrays.test
+++ b/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/query_for_arrays.test
@@ -23,15 +23,13 @@
 #
 # Uncached/Cached query
 #
-# 01. Start the contextBroker 'CB'
-# 02. Start contextProvider 'CP' (contextBroker functioning as contextProvider)
-# 03. Register an entity/attribute E1/A1 in broker, with CP as providing application
-# 04. Update/APPEND E1/A1(=CP) in CP - this is a non-primitive element e.g. an Array
-# 05. Query CP for E1/A1
-# 06. Query broker for E1/A1 (will go to CP and it will work, A1=CP is returned)
-# 07. Update/APPEND E1/A2(=broker) in broker - this is also a non-primitive element e.g. an Array
-# 08. Query broker for E1/A2 (broker's local info is returned (A2=broker))
-# 09. Query E1 in CB
+# 01. Register an entity/attribute E1/A1 in broker, with CP as providing application
+# 02. Update/APPEND E1/A1(=CP) in CP - this is a non-primitive element e.g. an Array
+# 03. Query CP for E1/A1
+# 04. Query broker for E1/A1 (will go to CP and it should work, A1=CP array is returned)
+# 05. Update/APPEND E1/A2(=broker) in broker - this is also a non-primitive element e.g. an Array
+# 06. Query broker for E1/A2 (broker's local info is returned (A2=broker))
+# 07. Query E1 in CB
 
 --NAME--
 Query Redirect Operation
@@ -44,14 +42,10 @@ brokerStart CP1 0
 
 
 --SHELL--
-echo "01. contextBroker running"
-echo "02. contextProvider running (contextBroker functioning as contextProvider)"
-echo
-echo
 
-echo "03. Register an entity/attribute E1/A1 in broker, with CP as providing application"
-url3="/v2/registrations"
-payload3='{
+echo "01. Register an entity/attribute E1/A1 in broker, with CP as providing application"
+echo "=================================================================================="
+payload='{
   "description": "Register a E1/A1 with CP as provider",
   "dataProvided": {
     "entities": [
@@ -71,14 +65,14 @@ payload3='{
      "legacyForwarding": true
   }
 }'
-orionCurl --url "$url3" --payload "$payload3"
+orionCurl --url /v2/registrations --payload "$payload"
 echo
 echo
 
 
-echo "04. Update/APPEND E1/A1(=CP) in CP"
-url4="/v1/updateContext"
-payload4='{
+echo "02. Update/APPEND E1/A1(=CP) in CP"
+echo "=================================="
+payload='{
   "contextElements": [
     {
       "type": "E",
@@ -95,14 +89,14 @@ payload4='{
   ],
   "updateAction": "APPEND"
 }'
-orionCurl --url "$url4" --payload "$payload4" --port $CP1_PORT
+orionCurl --url /v1/updateContext --payload "$payload" --port $CP1_PORT
 echo
 echo
 
 
-echo "05. Query CP for E1/A1"
-url5="/v1/queryContext"
-payload5='{
+echo "03. Query CP for E1/A1"
+echo "======================"
+payload='{
   "entities": [
     {
       "type": "E",
@@ -114,20 +108,21 @@ payload5='{
     "A1"
   ]
 }'
-orionCurl --url "$url5" --payload "$payload5" --port $CP1_PORT
+orionCurl --url /v1/queryContext --payload "$payload" --port $CP1_PORT
 echo
 echo
 
 
-echo "06. Query broker for E1/A1 (will go to CP and it should work, A1=CP array is returned)"
+echo "04. Query broker for E1/A1 (will go to CP and it should work, A1=CP array is returned)"
+echo "======================================================================================"
 orionCurl --url /v2/entities/E1/attrs/A1/value
 echo
 echo
 
 
-echo "07. Update/APPEND E1/A2(=broker) in broker"
-url7="/v1/updateContext"
-payload7='{
+echo "05. Update/APPEND E1/A2(=broker) in broker"
+echo "=========================================="
+payload='{
   "contextElements": [
     {
       "type": "E",
@@ -144,44 +139,40 @@ payload7='{
   ],
   "updateAction": "APPEND"
 }'
-orionCurl --url "$url7" --payload "$payload7"
+orionCurl --url /v1/updateContext --payload "$payload"
 echo
 echo
 
 
-echo "08. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)"
+echo "06. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)"
+echo "================================================================================"
 orionCurl --url /v2/entities/E1/attrs/A2/value --out "text/plain"
 echo
 echo
 
 
-echo "09. Query E1 in CB - expect two arrays returned"
+echo "07. Query E1 in CB - expect two arrays returned"
+echo "==============================================="
 orionCurl --url /v2/entities/E1
 echo
 echo
 
 
 --REGEXPECT--
-01. contextBroker running
-02. contextProvider running (contextBroker functioning as contextProvider)
-
-
-03. Register an entity/attribute E1/A1 in broker, with CP as providing application
-HTTP/1.1 200 OK
-Content-Length: 64
-Content-Type: application/json
+01. Register an entity/attribute E1/A1 in broker, with CP as providing application
+==================================================================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/registrations/REGEX([0-9a-f\-]{24})
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
-{
-    "duration": "PT24H",
-    "registrationId": "REGEX([0-9a-f]{24})"
-}
 
 
-04. Update/APPEND E1/A1(=CP) in CP
+02. Update/APPEND E1/A1(=CP) in CP
+==================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
+Content-Length: 187
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -194,7 +185,7 @@ Date: REGEX(.*)
                     {
                         "name": "A1",
                         "type": "Array",
-                        "value": ["Data", "from CP"]
+                        "value": ""
                     }
                 ],
                 "id": "E1",
@@ -210,9 +201,10 @@ Date: REGEX(.*)
 }
 
 
-05. Query CP for E1/A1
+03. Query CP for E1/A1
+======================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
+Content-Length: 203
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -225,7 +217,10 @@ Date: REGEX(.*)
                     {
                         "name": "A1",
                         "type": "Array",
-                        "value": ["Data", "from CP"]
+                        "value": [
+                            "Data",
+                            "from CP"
+                        ]
                     }
                 ],
                 "id": "E1",
@@ -241,23 +236,24 @@ Date: REGEX(.*)
 }
 
 
-06. Query broker for E1/A1 (will go to CP and it will work, A1=CP is returned)
+04. Query broker for E1/A1 (will go to CP and it should work, A1=CP array is returned)
+======================================================================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
+Content-Length: 18
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
-{
-    "metadata": {},
-    "type": "Array",
-    "value": ["Data", "from CP"]
-}
+[
+    "Data",
+    "from CP"
+]
 
 
-07. Update/APPEND E1/A2(=broker) in broker
+05. Update/APPEND E1/A2(=broker) in broker
+==========================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
+Content-Length: 187
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -270,7 +266,7 @@ Date: REGEX(.*)
                     {
                         "name": "A2",
                         "type": "Array",
-                        "value": ["Data", "from CB"]
+                        "value": ""
                     }
                 ],
                 "id": "E1",
@@ -286,22 +282,21 @@ Date: REGEX(.*)
 }
 
 
-08. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)
+06. Query broker for E1/A2 (will go to CB and should work, A2 array is returned)
+================================================================================
 HTTP/1.1 200 OK
-Content-Length: REGEX(\d+)
-Content-Type: application/json
+Content-Length: 18
+Content-Type: text/plain
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
 
-{
-    "metadata": {},
-    "type": "Array",
-    "value": ["Data", "from CB"]
-}
+["Data","from CB"]
 
-09. Query E1 in CB - expect two arrays returned
+
+07. Query E1 in CB - expect two arrays returned
+===============================================
 HTTP/1.1 200 OK
-Content-Length: 80
+Content-Length: 148
 Content-Type: application/json
 Fiware-Correlator: REGEX([0-9a-f\-]{36})
 Date: REGEX(.*)
@@ -309,22 +304,27 @@ Date: REGEX(.*)
 {
     "A1": {
         "metadata": {},
-        "type": "string",
-        "value": ["Data", "from CP"]
+        "type": "Array",
+        "value": [
+            "Data",
+            "from CP"
+        ]
     },
     "A2": {
         "metadata": {},
-        "type": "string",
-        "value": ["Data", "from CB"]
+        "type": "Array",
+        "value": [
+            "Data",
+            "from CB"
+        ]
     },
     "id": "E1",
-    "type": "T1"
+    "type": "E"
 }
 
 
 --TEARDOWN--
 brokerStop CB
 brokerStop CP1
-
 dbDrop CB
 dbDrop CP1

--- a/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/registration_without_provider.test
+++ b/test/functionalTest/cases/3162_context_providers_legacy_non_primitive/registration_without_provider.test
@@ -1,0 +1,82 @@
+# Copyright 2016 Telefonica Investigacion y Desarrollo, S.A.U
+#
+# This file is part of Orion Context Broker.
+#
+# Orion Context Broker is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# Orion Context Broker is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero
+# General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with Orion Context Broker. If not, see http://www.gnu.org/licenses/.
+#
+# For those usages not covered by this license please contact with
+# iot_support at tid dot es
+
+# VALGRIND_READY - to mark the test ready for valgrindTestSuite.sh
+
+--NAME--
+BUG 
+
+--SHELL-INIT--
+dbInit CB
+brokerStart CB
+
+--SHELL--
+
+#
+# 01. Create entity E1 without attributes
+# 02. Append new geo:box attribute (attr3) -> OK
+#
+
+echo "01. Create entity E1 without attributes"
+echo "======================================="
+payload='{
+  "id": "E1"
+}'
+orionCurl --url /v2/entities --payload "$payload"
+echo
+echo
+
+
+echo "02. Append new geo:box attribute (attr3) -> OK"
+echo "=============================================="
+payload='{
+  "attr3": {
+    "value": [ "-1, 1", "2, 2" ],
+    "type": "geo:box"
+  }
+}'
+orionCurl --url /v2/entities/E1/attrs --payload "$payload" -X POST
+echo
+echo
+
+
+--REGEXPECT--
+01. Create entity E1 without attributes
+=======================================
+HTTP/1.1 201 Created
+Content-Length: 0
+Location: /v2/entities/E1?type=Thing
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+02. Append new geo:box attribute (attr3) -> OK
+==============================================
+HTTP/1.1 204 No Content
+Content-Length: 0
+Fiware-Correlator: REGEX([0-9a-f\-]{36})
+Date: REGEX(.*)
+
+
+
+--TEARDOWN--
+brokerStop CB
+dbDrop CB


### PR DESCRIPTION
Fixed issue #3162 ... I think ...
The only real change is that in `ContextAttribute::ContextAttribute(ContextAttribute* caP, bool useDefaultType)` the compound is cloned and not "set to point to the same pointer".
I encountered some really important problems with leaks and when implementing help code to understand the leak, the leak ... disappeared ... :(
I have no explanation for this except that ... the current implementation works, with the vector of cloned compounds that later isn't used for anything at all, it just changes the timing.
So, the leak was a timing problem, not new to us ...
However, if the problem comes back, this new vector will be useful.

In lack of a real fix, this "workaround" solves the problem, at least temporarily ...